### PR TITLE
Recreate Quit channel on reset

### DIFF
--- a/service.go
+++ b/service.go
@@ -136,6 +136,7 @@ func (bs *BaseService) Reset() (bool, error) {
 		// whether or not we've started, we can reset
 		atomic.CompareAndSwapUint32(&bs.started, 1, 0)
 
+		bs.Quit = make(chan struct{})
 		return true, bs.impl.OnReset()
 	} else {
 		if bs.log != nil {


### PR DESCRIPTION
don't think that user should do this thing him/herself

Without this PR it is impossible to call `Stop(); Reset(); Start(); Stop()` without getting the error `close of closed channel`.